### PR TITLE
Make sure telemetry doesn't break when plain kedro command called

### DIFF
--- a/kedro_telemetry/plugin.py
+++ b/kedro_telemetry/plugin.py
@@ -63,7 +63,7 @@ class KedroTelemetryCLIHooks:
     def before_command_run(self, project_metadata, command_args):
         """Hook implementation to send command run data to Heap"""
         # pylint: disable=no-self-use
-        main_command = command_args[0]
+        main_command = command_args[0] if command_args else "kedro"
         if not project_metadata:
             return
 
@@ -121,7 +121,7 @@ def _format_user_cli_data(command_args, project_metadata):
 
     return {
         "username": hashed_username.hexdigest() if hashed_username else "anonymous",
-        "command": f"kedro {' '.join(command_args)}",
+        "command": f"kedro {' '.join(command_args)}" if command_args else "kedro",
         "package_name": hashed_package_name.hexdigest(),
         "project_name": hashed_project_name.hexdigest(),
         "project_version": project_version,


### PR DESCRIPTION
Currently, calling `kedro` when kedro-telemetry is installed will result in an error:

```
2021-06-23 14:22:53,023 - root - INFO - Registered CLI hooks from 1 installed plugin(s): kedro-telemetry-0.1.0
Traceback (most recent call last):
  File "/Users/merel_theisen/anaconda3/envs/kedro/bin/kedro", line 33, in <module>
    sys.exit(load_entry_point('kedro', 'console_scripts', 'kedro')())
  File "/Users/merel_theisen/Projects/private-kedro/kedro/framework/cli/cli.py", line 226, in main
    cli_collection()
  File "/Users/merel_theisen/anaconda3/envs/kedro/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/merel_theisen/Projects/private-kedro/kedro/framework/cli/cli.py", line 168, in main
    project_metadata=self._metadata, command_args=args
  File "/Users/merel_theisen/anaconda3/envs/kedro/lib/python3.7/site-packages/pluggy/hooks.py", line 286, in __call__
    return self._hookexec(self, self.get_hookimpls(), kwargs)
  File "/Users/merel_theisen/anaconda3/envs/kedro/lib/python3.7/site-packages/pluggy/manager.py", line 93, in _hookexec
    return self._inner_hookexec(hook, methods, kwargs)
  File "/Users/merel_theisen/anaconda3/envs/kedro/lib/python3.7/site-packages/pluggy/manager.py", line 87, in <lambda>
    firstresult=hook.spec.opts.get("firstresult") if hook.spec else False,
  File "/Users/merel_theisen/anaconda3/envs/kedro/lib/python3.7/site-packages/pluggy/callers.py", line 208, in _multicall
    return outcome.get_result()
  File "/Users/merel_theisen/anaconda3/envs/kedro/lib/python3.7/site-packages/pluggy/callers.py", line 80, in get_result
    raise ex[1].with_traceback(ex[2])
  File "/Users/merel_theisen/anaconda3/envs/kedro/lib/python3.7/site-packages/pluggy/callers.py", line 187, in _multicall
    res = hook_impl.function(*args)
  File "/Users/merel_theisen/anaconda3/envs/kedro/lib/python3.7/site-packages/kedro_telemetry/plugin.py", line 66, in before_command_run
    main_command = command_args[0]
IndexError: list index out of range
```

This PR provides a fix, where if just kedro is called, the plugin will report that to heap and on the CLI will see the usage of the Kedro CLI as expected.

