### PR TITLE
[FEATURE] Mask command arguments client-side

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,7 @@
 # Copied from Black
 
 [flake8]
-ignore = E203, E266, E501, W503
+ignore = E126, E203, E231, E266, E501, W503
 max-line-length = 80
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ You have furthermore certain data subject rights under applicable laws (incl. ri
 
 Besides the hashed host- and username, we collect the following project-related information. Again, we rely on your consent to do so:
 
-* CLI command that was run (e.g. `kedro run --env test`)
+* CLI command that was run with arguments masked (e.g. `kedro run --env=test` → `kedro run --env *****`)
 * _(Hashed)_ Package name
 * _(Hashed)_ Project name
 * Project version

--- a/README.md
+++ b/README.md
@@ -22,15 +22,17 @@ You have furthermore certain data subject rights under applicable laws (incl. ri
 
 ### What other information do you collect?
 
-Besides the hashed host- and username, we collect the following project-related information. Again, we rely on your consent to do so:
+Besides the hashed host and username, we collect the following project-related information. Again, we rely on your consent to do so:
 
-* CLI command that was run with arguments masked (e.g. `kedro run --env=test` → `kedro run --env *****`)
-* _(Hashed)_ Package name
-* _(Hashed)_ Project name
-* Project version
-* `kedro-telemetry` version
-* Python version
-* Operating system used
+|Description|Example Input|What we received|
+|-|-|-|
+|CLI command (masked arguments)|`kedro run --pipeline=ds --env=test`|`kedro run --pipeline ***** --env *****`|
+|_(Hashed)_ Package name|my-project|1c7cd944c28cd888904f3efc2345198507...|
+|_(Hashed)_ Project name|my_project|a6392d359362dc9827cf8688c9d634520e...|
+|`kedro` project version|0.17.6|0.17.6|
+|`kedro-telemetry` version|0.1.2|0.1.2|
+|Python version|3.8.10 (default, Jun  2 2021, 10:49:15)|3.8.10 (default, Jun  2 2021, 10:49:15)|
+|Operating system used|darwin|darwin|
 
 ### How do I consent to the use of Kedro-Telemetry?
 

--- a/kedro_telemetry/masking.py
+++ b/kedro_telemetry/masking.py
@@ -79,7 +79,9 @@ def _recurse_cli(
         if get_help:  # gets formatted CLI help incl params for printing
             io_dict[cli_element.name] = cli_element.get_help(ctx)
         else:  # gets params for structure purposes
-            nested_parameter_list = [option.opts for option in cli_element.get_params(ctx)]
+            nested_parameter_list = [
+                option.opts for option in cli_element.get_params(ctx)
+            ]
             io_dict[cli_element.name] = dict.fromkeys(
                 [item for sublist in nested_parameter_list for item in sublist], None
             )
@@ -94,7 +96,7 @@ def get_cli_structure(
     Convenience wrapper function for `_recurse_cli` to work within
     `click.Context` and return a `dict`.
     """
-    output: Dict[str, Any] = dict()
+    output: Dict[str, Any] = {}
     with click.Context(cli_obj) as ctx:  # type: ignore
         _recurse_cli(cli_obj, ctx, output, get_help)
     return output

--- a/kedro_telemetry/masking.py
+++ b/kedro_telemetry/masking.py
@@ -28,7 +28,7 @@
 
 """Module containing command masking functionality."""
 
-from typing import Any, Dict, List, Set, Union
+from typing import Any, Dict, Iterator, List, Set, Tuple, Union
 
 import click
 
@@ -125,7 +125,7 @@ def _get_vocabulary(cli_struct: Dict[str, Any]) -> Set[str]:
     return vocabulary
 
 
-def _recursive_items(dictionary: Dict[Any, Any]):
+def _recursive_items(dictionary: Dict[Any, Any]) -> Iterator[Tuple[str, Any]]:
     for key, value in dictionary.items():
         if isinstance(value, dict):
             yield key, None

--- a/kedro_telemetry/masking.py
+++ b/kedro_telemetry/masking.py
@@ -85,7 +85,7 @@ def _recurse_cli(
             )
 
 
-def get_cli_structure(
+def _get_cli_structure(
     cli_obj: Union[click.Command, click.Group, click.CommandCollection],
     get_help: bool = False,
 ) -> Dict[str, Any]:
@@ -100,7 +100,7 @@ def get_cli_structure(
     return output
 
 
-def mask_kedro_cli(cli_struct: Dict[str, Any], command_args: List[str]) -> List[str]:
+def _mask_kedro_cli(cli_struct: Dict[str, Any], command_args: List[str]) -> List[str]:
     """Takes a dynamic vocabulary (based on `KedroCLI`) and returns
     a masked CLI input"""
     output = []

--- a/kedro_telemetry/masking.py
+++ b/kedro_telemetry/masking.py
@@ -1,0 +1,134 @@
+# Copyright 2021 QuantumBlack Visual Analytics Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+# NONINFRINGEMENT. IN NO EVENT WILL THE LICENSOR OR OTHER CONTRIBUTORS
+# BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF, OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# The QuantumBlack Visual Analytics Limited ("QuantumBlack") name and logo
+# (either separately or in combination, "QuantumBlack Trademarks") are
+# trademarks of QuantumBlack. The License does not grant you any right or
+# license to the QuantumBlack Trademarks. You may not use the QuantumBlack
+# Trademarks or any confusingly similar mark as a trademark for your product,
+# or use the QuantumBlack Trademarks in any other manner that might cause
+# confusion in the marketplace, including but not limited to in advertising,
+# on websites, or on software.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Module containing command masking functionality."""
+
+from typing import Any, Dict, List, Set, Union
+
+import click
+
+
+def _recurse_cli(
+    cli_element: Union[click.Command, click.Group, click.CommandCollection],
+    ctx: click.Context,
+    io_dict: Dict[str, Any],
+    get_help: bool = False,
+) -> None:
+    """
+    Code copied over from kedro.tools.cli to maintain backwards compatibility
+    with previous versions of kedro (<0.17.5).
+
+    Recursive function that checks the type of the command (key) and decides:
+    1. In case of `click.Group` or `click.CommandCollection` (aggregate commands),
+        the function collects the name and recurses one layer deeper
+        for each sub-command.
+    2. In case of `click.Command`, the terminus command has been reached. The function
+        collects the name, parameters and args, flattens them and saves them as
+        dictionary keys.
+    Args:
+        cli_element: CLI Collection as input for recursion, typically `KedroCLI`.
+        ctx: Click Context, created by the wrapper function.
+        io_dict: Input-output dictionary, mutated during the recursion.
+        get_help: Boolean fork - allows either:
+            raw structure - nested dictionary until final value of `None`
+            help structure - nested dictionary where leaves are `--help` cmd output
+
+    Returns:
+        None (underlying `io_dict` is mutated by the recursion)
+    """
+    if isinstance(cli_element, (click.Group, click.CommandCollection)):
+        element_name = cli_element.name or "kedro"
+        io_dict[element_name] = {}
+        for _sc in cli_element.list_commands(ctx):
+            _recurse_cli(  # type: ignore
+                cli_element.get_command(ctx, _sc), ctx, io_dict[element_name], get_help,
+            )
+
+    elif isinstance(cli_element, click.Command):
+        if get_help:  # gets formatted CLI help incl params for printing
+            io_dict[cli_element.name] = cli_element.get_help(ctx)
+        else:  # gets params for structure purposes
+            l_of_l = [_o.opts for _o in cli_element.get_params(ctx)]
+            io_dict[cli_element.name] = dict.fromkeys(
+                [item for sublist in l_of_l for item in sublist], None
+            )
+
+
+def get_cli_structure(
+    cli_obj: Union[click.Command, click.Group, click.CommandCollection],
+    get_help: bool = False,
+) -> Dict[str, Any]:
+    """Code copied over from kedro.tools.cli to maintain backwards compatibility
+    with previous versions of kedro (<0.17.5).
+    Convenience wrapper function for `_recurse_cli` to work within
+    `click.Context` and return a `dict`.
+    """
+    output: Dict[str, Any] = {}
+    with click.Context(cli_obj) as ctx:  # type: ignore
+        _recurse_cli(cli_obj, ctx, output, get_help)
+    return output
+
+
+def mask_kedro_cli(cli_struct: Dict[str, Any], command_args: List[str]) -> List[str]:
+    """Takes a dynamic vocabulary (based on `KedroCLI`) and returns
+    a masked CLI input"""
+    output = []
+    mask = "*****"
+    vocabulary = _get_vocabulary(cli_struct)
+    for arg in command_args:
+        if arg.startswith("-"):
+            for arg_part in arg.split("="):
+                if arg_part in vocabulary:
+                    output.append(arg_part)
+                elif arg_part:
+                    output.append(mask)
+        else:
+            if arg in vocabulary:
+                output.append(arg)
+            elif arg:
+                output.append(mask)
+    return output
+
+
+def _get_vocabulary(cli_struct: Dict[str, Any]) -> Set[str]:
+    """Builds a unique whitelist of terms - a vocabulary"""
+    vocabulary = {"-h", "--version"}  # -h help and version args are not in by default
+    for _k, _v in _recursive_items(cli_struct):
+        vocabulary.add(_k)
+        if _v:
+            vocabulary.add(_v)
+    return vocabulary
+
+
+def _recursive_items(dictionary: Dict[Any, Any]):
+    for key, value in dictionary.items():
+        if isinstance(value, dict):
+            yield key, None
+            yield from _recursive_items(value)
+        else:
+            yield key, value

--- a/kedro_telemetry/masking.py
+++ b/kedro_telemetry/masking.py
@@ -32,6 +32,8 @@ from typing import Any, Dict, Iterator, List, Set, Tuple, Union
 
 import click
 
+MASK = "*****"
+
 
 def _recurse_cli(
     cli_element: Union[click.Command, click.Group, click.CommandCollection],
@@ -98,7 +100,6 @@ def mask_kedro_cli(cli_struct: Dict[str, Any], command_args: List[str]) -> List[
     """Takes a dynamic vocabulary (based on `KedroCLI`) and returns
     a masked CLI input"""
     output = []
-    mask = "*****"
     vocabulary = _get_vocabulary(cli_struct)
     for arg in command_args:
         if arg.startswith("-"):
@@ -106,12 +107,12 @@ def mask_kedro_cli(cli_struct: Dict[str, Any], command_args: List[str]) -> List[
                 if arg_part in vocabulary:
                     output.append(arg_part)
                 elif arg_part:
-                    output.append(mask)
+                    output.append(MASK)
         else:
             if arg in vocabulary:
                 output.append(arg)
             elif arg:
-                output.append(mask)
+                output.append(MASK)
     return output
 
 

--- a/kedro_telemetry/masking.py
+++ b/kedro_telemetry/masking.py
@@ -27,8 +27,6 @@
 # limitations under the License.
 
 """Module containing command masking functionality."""
-from functools import partial
-from operator import is_not
 from typing import Any, Dict, Iterator, List, Set, Union
 
 import click
@@ -125,9 +123,7 @@ def mask_kedro_cli(cli_struct: Dict[str, Any], command_args: List[str]) -> List[
 def _get_vocabulary(cli_struct: Dict[str, Any]) -> Set[str]:
     """Builds a unique whitelist of terms - a vocabulary"""
     vocabulary = {"-h", "--version"}  # -h help and version args are not in by default
-    cli_dynamic_vocabulary = filter(
-        partial(is_not, None), set(_recursive_items(cli_struct))
-    )
+    cli_dynamic_vocabulary = set(_recursive_items(cli_struct)) - {None}
     vocabulary.update(cli_dynamic_vocabulary)
     return vocabulary
 

--- a/kedro_telemetry/masking.py
+++ b/kedro_telemetry/masking.py
@@ -67,18 +67,21 @@ def _recurse_cli(
     if isinstance(cli_element, (click.Group, click.CommandCollection)):
         element_name = cli_element.name or "kedro"
         io_dict[element_name] = {}
-        for _sc in cli_element.list_commands(ctx):
+        for sub_command in cli_element.list_commands(ctx):
             _recurse_cli(  # type: ignore
-                cli_element.get_command(ctx, _sc), ctx, io_dict[element_name], get_help,
+                cli_element.get_command(ctx, sub_command),
+                ctx,
+                io_dict[element_name],
+                get_help,
             )
 
     elif isinstance(cli_element, click.Command):
         if get_help:  # gets formatted CLI help incl params for printing
             io_dict[cli_element.name] = cli_element.get_help(ctx)
         else:  # gets params for structure purposes
-            l_of_l = [_o.opts for _o in cli_element.get_params(ctx)]
+            nested_list = [_o.opts for _o in cli_element.get_params(ctx)]
             io_dict[cli_element.name] = dict.fromkeys(
-                [item for sublist in l_of_l for item in sublist], None
+                [item for sublist in nested_list for item in sublist], None
             )
 
 

--- a/kedro_telemetry/masking.py
+++ b/kedro_telemetry/masking.py
@@ -67,9 +67,9 @@ def _recurse_cli(
     if isinstance(cli_element, (click.Group, click.CommandCollection)):
         element_name = cli_element.name or "kedro"
         io_dict[element_name] = {}
-        for sub_command in cli_element.list_commands(ctx):
+        for command_name in cli_element.list_commands(ctx):
             _recurse_cli(  # type: ignore
-                cli_element.get_command(ctx, sub_command),
+                cli_element.get_command(ctx, command_name),
                 ctx,
                 io_dict[element_name],
                 get_help,
@@ -79,9 +79,9 @@ def _recurse_cli(
         if get_help:  # gets formatted CLI help incl params for printing
             io_dict[cli_element.name] = cli_element.get_help(ctx)
         else:  # gets params for structure purposes
-            nested_list = [_o.opts for _o in cli_element.get_params(ctx)]
+            nested_parameter_list = [option.opts for option in cli_element.get_params(ctx)]
             io_dict[cli_element.name] = dict.fromkeys(
-                [item for sublist in nested_list for item in sublist], None
+                [item for sublist in nested_parameter_list for item in sublist], None
             )
 
 
@@ -94,7 +94,7 @@ def get_cli_structure(
     Convenience wrapper function for `_recurse_cli` to work within
     `click.Context` and return a `dict`.
     """
-    output: Dict[str, Any] = {}
+    output: Dict[str, Any] = dict()
     with click.Context(cli_obj) as ctx:  # type: ignore
         _recurse_cli(cli_obj, ctx, output, get_help)
     return output

--- a/kedro_telemetry/plugin.py
+++ b/kedro_telemetry/plugin.py
@@ -112,7 +112,7 @@ class KedroTelemetryCLIHooks:
         )
 
 
-def _format_user_cli_data(command_args, project_metadata):
+def _format_user_cli_data(command_args: List[str], project_metadata: ProjectMetadata):
     """Hash username, format CLI command, system and project data to send to Heap."""
     hashed_username = ""
     try:
@@ -206,6 +206,10 @@ def _confirm_consent(telemetry_file_path: Path) -> bool:
             return True
         yaml.dump({"consent": False}, telemetry_file)
         return False
+
+
+def _mask_commands(command_args: List[str]) -> List[str]:
+    pass
 
 
 cli_hooks = KedroTelemetryCLIHooks()

--- a/kedro_telemetry/plugin.py
+++ b/kedro_telemetry/plugin.py
@@ -47,7 +47,7 @@ from kedro.framework.cli.hooks import cli_hook_impl
 from kedro.framework.startup import ProjectMetadata
 
 from kedro_telemetry import __version__ as telemetry_version
-from kedro_telemetry.masking import get_cli_structure, mask_kedro_cli
+from kedro_telemetry.masking import _get_cli_structure, _mask_kedro_cli
 
 HEAP_APPID_PROD = "2388822444"
 
@@ -72,8 +72,8 @@ class KedroTelemetryCLIHooks:
 
         # get KedroCLI and its structure from actual project root
         cli = KedroCLI(project_path=Path.cwd())
-        cli_struct = get_cli_structure(cli_obj=cli, get_help=False)
-        masked_command_args = mask_kedro_cli(
+        cli_struct = _get_cli_structure(cli_obj=cli, get_help=False)
+        masked_command_args = _mask_kedro_cli(
             cli_struct=cli_struct, command_args=command_args
         )
         main_command = masked_command_args[0] if masked_command_args else "kedro"

--- a/kedro_telemetry/plugin.py
+++ b/kedro_telemetry/plugin.py
@@ -76,8 +76,6 @@ class KedroTelemetryCLIHooks:
         masked_command_args = mask_kedro_cli(
             cli_struct=cli_struct, command_args=command_args
         )
-        logger.info("Masked Kedro CLI: %s", masked_command_args)
-
         main_command = masked_command_args[0] if masked_command_args else "kedro"
         if not project_metadata:  # in package mode
             return

--- a/kedro_telemetry/plugin.py
+++ b/kedro_telemetry/plugin.py
@@ -282,7 +282,7 @@ def mask_kedro_cli(cli_struct: Dict[str, Any], command_args: List[str]) -> List[
 
 def _get_vocabulary(cli_struct: Dict[str, Any]) -> Set[str]:
     """Builds a unique whitelist of terms - a vocabulary"""
-    vocabulary = {"-h", "--help"}  # help args are not in by default
+    vocabulary = {"-h", "--version"}  # -h help and version args are not in by default
     for _k, _v in _recursive_items(cli_struct):
         vocabulary.add(_k)
         if _v:

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -39,6 +39,7 @@ from kedro.framework.cli.cli import KedroCLI, cli
 from kedro.framework.startup import ProjectMetadata
 
 from kedro_telemetry.masking import (
+    MASK,
     _get_vocabulary,
     _recursive_items,
     get_cli_structure,
@@ -202,7 +203,7 @@ class TestCLIMasking:
                     }
                 },
                 ["command_a", "--param1=foo"],
-                ["command_a", "--param1", "*****"],
+                ["command_a", "--param1", MASK],
             ),
             (
                 {
@@ -212,7 +213,7 @@ class TestCLIMasking:
                     }
                 },
                 ["command_a", "--param1= foo"],
-                ["command_a", "--param1", "*****"],
+                ["command_a", "--param1", MASK],
             ),
             (
                 {
@@ -222,7 +223,7 @@ class TestCLIMasking:
                     }
                 },
                 ["command_a", "-p", "bar"],
-                ["command_a", "-p", "*****"],
+                ["command_a", "-p", MASK],
             ),
             (
                 {
@@ -232,7 +233,7 @@ class TestCLIMasking:
                     }
                 },
                 ["command_a", "-xyz", "bar"],
-                ["command_a", "*****", "*****"],
+                ["command_a", MASK, MASK],
             ),
             (
                 {
@@ -242,16 +243,7 @@ class TestCLIMasking:
                     }
                 },
                 ["none", "of", "this", "should", "be", "seen", "except", "command_a"],
-                [
-                    "*****",
-                    "*****",
-                    "*****",
-                    "*****",
-                    "*****",
-                    "*****",
-                    "*****",
-                    "command_a",
-                ],
+                [MASK, MASK, MASK, MASK, MASK, MASK, MASK, MASK,],
             ),
         ],
     )

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -39,10 +39,10 @@ from kedro.framework.startup import ProjectMetadata
 
 from kedro_telemetry.masking import (
     MASK,
+    _get_cli_structure,
     _get_vocabulary,
+    _mask_kedro_cli,
     _recursive_items,
-    get_cli_structure,
-    mask_kedro_cli,
 )
 
 REPO_NAME = "cli_tools_dummy_project"
@@ -95,13 +95,15 @@ class TestCLIMasking:
             return_value=Module(cli=cli),
         )
         mocker.patch(
-            "kedro.framework.cli.cli._is_project", return_value=True,
+            "kedro.framework.cli.cli._is_project",
+            return_value=True,
         )
         mocker.patch(
-            "kedro.framework.cli.cli.bootstrap_project", return_value=fake_metadata,
+            "kedro.framework.cli.cli.bootstrap_project",
+            return_value=fake_metadata,
         )
         kedro_cli = KedroCLI(fake_metadata.project_path)
-        raw_cli_structure = get_cli_structure(kedro_cli, get_help=False)
+        raw_cli_structure = _get_cli_structure(kedro_cli, get_help=False)
 
         # raw CLI structure tests
         assert isinstance(raw_cli_structure, dict)
@@ -122,13 +124,15 @@ class TestCLIMasking:
             return_value=Module(cli=cli),
         )
         mocker.patch(
-            "kedro.framework.cli.cli._is_project", return_value=True,
+            "kedro.framework.cli.cli._is_project",
+            return_value=True,
         )
         mocker.patch(
-            "kedro.framework.cli.cli.bootstrap_project", return_value=fake_metadata,
+            "kedro.framework.cli.cli.bootstrap_project",
+            return_value=fake_metadata,
         )
         kedro_cli = KedroCLI(fake_metadata.project_path)
-        raw_cli_structure = get_cli_structure(kedro_cli, get_help=False)
+        raw_cli_structure = _get_cli_structure(kedro_cli, get_help=False)
         assert isinstance(raw_cli_structure["kedro"]["new"], dict)
         assert sorted(list(raw_cli_structure["kedro"]["new"].keys())) == sorted(
             [
@@ -156,13 +160,15 @@ class TestCLIMasking:
             return_value=Module(cli=cli),
         )
         mocker.patch(
-            "kedro.framework.cli.cli._is_project", return_value=True,
+            "kedro.framework.cli.cli._is_project",
+            return_value=True,
         )
         mocker.patch(
-            "kedro.framework.cli.cli.bootstrap_project", return_value=fake_metadata,
+            "kedro.framework.cli.cli.bootstrap_project",
+            return_value=fake_metadata,
         )
         kedro_cli = KedroCLI(fake_metadata.project_path)
-        help_cli_structure = get_cli_structure(kedro_cli, get_help=True)
+        help_cli_structure = _get_cli_structure(kedro_cli, get_help=True)
 
         assert isinstance(help_cli_structure, dict)
         assert isinstance(help_cli_structure["kedro"], dict)
@@ -274,6 +280,6 @@ class TestCLIMasking:
     def test_mask_kedro_cli(
         self, input_cli_structure, input_command_args, expected_masked_args
     ):
-        assert expected_masked_args == mask_kedro_cli(
+        assert expected_masked_args == _mask_kedro_cli(
             cli_struct=input_cli_structure, command_args=input_command_args
         )

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -200,8 +200,8 @@ class TestCLIMasking:
         ],
     )
     def test_recursive_items(self, input_dict, expected_output_count):
-        assert expected_output_count == sum(
-            1 for _ in _recursive_items(dictionary=input_dict)
+        assert expected_output_count == len(
+            list(_recursive_items(dictionary=input_dict))
         )
 
     def test_recursive_items_empty(self):

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -1,0 +1,263 @@
+# Copyright 2021 QuantumBlack Visual Analytics Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+# OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+# NONINFRINGEMENT. IN NO EVENT WILL THE LICENSOR OR OTHER CONTRIBUTORS
+# BE LIABLE FOR ANY CLAIM, DAMAGES, OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF, OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+#
+# The QuantumBlack Visual Analytics Limited ("QuantumBlack") name and logo
+# (either separately or in combination, "QuantumBlack Trademarks") are
+# trademarks of QuantumBlack. The License does not grant you any right or
+# license to the QuantumBlack Trademarks. You may not use the QuantumBlack
+# Trademarks or any confusingly similar mark as a trademark for your product,
+# or use the QuantumBlack Trademarks in any other manner that might cause
+# confusion in the marketplace, including but not limited to in advertising,
+# on websites, or on software.
+#
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# pylint: disable=protected-access
+
+"""Testing module for CLI tools"""
+import shutil
+import tempfile
+from collections import namedtuple
+from pathlib import Path
+
+import pytest
+from kedro import __version__ as kedro_version
+from kedro.framework.cli.cli import KedroCLI, cli
+from kedro.framework.startup import ProjectMetadata
+
+from kedro_telemetry.masking import (
+    _get_vocabulary,
+    _recursive_items,
+    get_cli_structure,
+    mask_kedro_cli,
+)
+
+REPO_NAME = "cli_tools_dummy_project"
+PACKAGE_NAME = "cli_tools_dummy_package"
+DEFAULT_KEDRO_COMMANDS = [
+    "activate-nbstripout",
+    "build-docs",
+    "build-reqs",
+    "catalog",
+    "install",
+    "ipython",
+    "jupyter",
+    "lint",
+    "new",
+    "package",
+    "pipeline",
+    "registry",
+    "run",
+    "starter",
+    "test",
+]
+
+
+@pytest.fixture(scope="function")
+def fake_root_dir():
+    # using tempfile as tmp_path fixture doesn't support module scope
+    tmpdir = tempfile.mkdtemp()
+    try:
+        yield Path(tmpdir).resolve()
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+@pytest.fixture(scope="function")
+def fake_metadata(fake_root_dir):
+    metadata = ProjectMetadata(
+        fake_root_dir / REPO_NAME / "pyproject.toml",
+        PACKAGE_NAME,
+        "CLI Tools Testing Project",
+        fake_root_dir / REPO_NAME,
+        kedro_version,
+        fake_root_dir / REPO_NAME / "src",
+    )
+    return metadata
+
+
+class TestCLIMasking:
+    def test_get_cli_structure(self, mocker, fake_metadata):
+        # This test is a replica of `kedro.tests.tools.test_cli.py` tests
+        # This duplication is to maintain backwards compatibility
+        Module = namedtuple("Module", ["cli"])
+        mocker.patch(
+            "kedro.framework.cli.cli.importlib.import_module",
+            return_value=Module(cli=cli),
+        )
+        mocker.patch(
+            "kedro.framework.cli.cli._is_project", return_value=True,
+        )
+        mocker.patch(
+            "kedro.framework.cli.cli.bootstrap_project", return_value=fake_metadata,
+        )
+        kedro_cli = KedroCLI(fake_metadata.project_path)
+        raw_cli_structure = get_cli_structure(kedro_cli, get_help=False)
+        help_cli_structure = get_cli_structure(kedro_cli, get_help=True)
+
+        # raw CLI structure tests
+        assert isinstance(raw_cli_structure, dict)
+        assert isinstance(raw_cli_structure["kedro"], dict)
+
+        for k, v in raw_cli_structure["kedro"].items():
+            assert isinstance(k, str)
+            assert isinstance(v, dict)
+
+        assert sorted(list(raw_cli_structure["kedro"])) == sorted(
+            DEFAULT_KEDRO_COMMANDS
+        )
+
+        # get_help CLI structure tests
+        assert isinstance(help_cli_structure, dict)
+        assert isinstance(help_cli_structure["kedro"], dict)
+
+        for k, v in help_cli_structure["kedro"].items():
+            assert isinstance(k, str)
+            if isinstance(v, dict):
+                for sub_key in v:
+                    assert isinstance(help_cli_structure["kedro"][k][sub_key], str)
+                    assert help_cli_structure["kedro"][k][sub_key].startswith(
+                        "Usage:  [OPTIONS]"
+                    )
+            elif isinstance(v, str):
+                assert v.startswith("Usage:  [OPTIONS]")
+
+        assert sorted(list(help_cli_structure["kedro"])) == sorted(
+            DEFAULT_KEDRO_COMMANDS
+        )
+
+    @pytest.mark.parametrize(
+        "input_dict, expected_output_count",
+        [
+            ({}, 0),
+            ({"a": "foo"}, 1),
+            ({"a": {"b": "bar"}, "c": {"baz"}}, 3),
+            (
+                {
+                    "a": {"b": "bar"},
+                    "c": None,
+                    "d": {"e": "fizz"},
+                    "f": {"g": {"h": "buzz"}},
+                },
+                8,
+            ),
+        ],
+    )
+    def test_recursive_items(self, input_dict, expected_output_count):
+        assert expected_output_count == sum(
+            1 for _ in _recursive_items(dictionary=input_dict)
+        )
+
+    def test_recursive_items_empty(self):
+        assert len(list(_recursive_items({}))) == 0
+
+    @pytest.mark.parametrize(
+        "input_dict, expected_tuple",
+        [
+            (
+                {
+                    "a": {"b": "bar"},
+                    "c": None,
+                    "d": {"e": "fizz"},
+                    "f": {"g": {"h": "buzz"}},
+                },
+                ("h", "buzz"),
+            ),
+            ({"a": {},}, ("a", None)),
+        ],
+    )
+    def test_recursive_items_last_leaf(self, input_dict, expected_tuple):
+        assert list(_recursive_items(input_dict))[-1] == expected_tuple
+
+    def test_get_vocabulary_empty(self):
+        assert _get_vocabulary({}) == {"-h", "--version"}
+
+    @pytest.mark.parametrize(
+        "input_cli_structure, input_command_args, expected_masked_args",
+        [
+            ({}, [], []),
+            (
+                {"kedro": {"command_a": None, "command_b": None}},
+                ["command_a"],
+                ["command_a"],
+            ),
+            (
+                {
+                    "kedro": {
+                        "command_a": {"--param1": None, "--param2": None},
+                        "command_b": None,
+                    }
+                },
+                ["command_a", "--param1=foo"],
+                ["command_a", "--param1", "*****"],
+            ),
+            (
+                {
+                    "kedro": {
+                        "command_a": {"--param1": None, "--param2": None},
+                        "command_b": None,
+                    }
+                },
+                ["command_a", "--param1= foo"],
+                ["command_a", "--param1", "*****"],
+            ),
+            (
+                {
+                    "kedro": {
+                        "command_a": {"--param": None, "-p": None},
+                        "command_b": None,
+                    }
+                },
+                ["command_a", "-p", "bar"],
+                ["command_a", "-p", "*****"],
+            ),
+            (
+                {
+                    "kedro": {
+                        "command_a": {"--param": None, "-p": None},
+                        "command_b": None,
+                    }
+                },
+                ["command_a", "-xyz", "bar"],
+                ["command_a", "*****", "*****"],
+            ),
+            (
+                {
+                    "kedro": {
+                        "command_a": {"--param": None, "-p": None},
+                        "command_b": None,
+                    }
+                },
+                ["none", "of", "this", "should", "be", "seen", "except", "command_a"],
+                [
+                    "*****",
+                    "*****",
+                    "*****",
+                    "*****",
+                    "*****",
+                    "*****",
+                    "*****",
+                    "command_a",
+                ],
+            ),
+        ],
+    )
+    def test_mask_kedro_cli(
+        self, input_cli_structure, input_command_args, expected_masked_args
+    ):
+        assert expected_masked_args == mask_kedro_cli(
+            cli_struct=input_cli_structure, command_args=input_command_args
+        )

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -144,8 +144,8 @@ class TestCLIMasking:
         "input_dict, expected_output_count",
         [
             ({}, 0),
-            ({"a": "foo"}, 1),
-            ({"a": {"b": "bar"}, "c": {"baz"}}, 3),
+            ({"a": "foo"}, 2),
+            ({"a": {"b": "bar"}, "c": {"baz"}}, 5),
             (
                 {
                     "a": {"b": "bar"},
@@ -153,7 +153,7 @@ class TestCLIMasking:
                     "d": {"e": "fizz"},
                     "f": {"g": {"h": "buzz"}},
                 },
-                8,
+                12,
             ),
         ],
     )
@@ -164,24 +164,6 @@ class TestCLIMasking:
 
     def test_recursive_items_empty(self):
         assert len(list(_recursive_items({}))) == 0
-
-    @pytest.mark.parametrize(
-        "input_dict, expected_tuple",
-        [
-            (
-                {
-                    "a": {"b": "bar"},
-                    "c": None,
-                    "d": {"e": "fizz"},
-                    "f": {"g": {"h": "buzz"}},
-                },
-                ("h", "buzz"),
-            ),
-            ({"a": {},}, ("a", None)),
-        ],
-    )
-    def test_recursive_items_last_leaf(self, input_dict, expected_tuple):
-        assert list(_recursive_items(input_dict))[-1] == expected_tuple
 
     def test_get_vocabulary_empty(self):
         assert _get_vocabulary({}) == {"-h", "--version"}
@@ -243,7 +225,7 @@ class TestCLIMasking:
                     }
                 },
                 ["none", "of", "this", "should", "be", "seen", "except", "command_a"],
-                [MASK, MASK, MASK, MASK, MASK, MASK, MASK, MASK,],
+                [MASK, MASK, MASK, MASK, MASK, MASK, MASK, "command_a"],
             ),
         ],
     )

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -94,13 +94,9 @@ class TestCLIMasking:
             "kedro.framework.cli.cli.importlib.import_module",
             return_value=Module(cli=cli),
         )
+        mocker.patch("kedro.framework.cli.cli._is_project", return_value=True)
         mocker.patch(
-            "kedro.framework.cli.cli._is_project",
-            return_value=True,
-        )
-        mocker.patch(
-            "kedro.framework.cli.cli.bootstrap_project",
-            return_value=fake_metadata,
+            "kedro.framework.cli.cli.bootstrap_project", return_value=fake_metadata
         )
         kedro_cli = KedroCLI(fake_metadata.project_path)
         raw_cli_structure = _get_cli_structure(kedro_cli, get_help=False)
@@ -123,13 +119,9 @@ class TestCLIMasking:
             "kedro.framework.cli.cli.importlib.import_module",
             return_value=Module(cli=cli),
         )
+        mocker.patch("kedro.framework.cli.cli._is_project", return_value=True)
         mocker.patch(
-            "kedro.framework.cli.cli._is_project",
-            return_value=True,
-        )
-        mocker.patch(
-            "kedro.framework.cli.cli.bootstrap_project",
-            return_value=fake_metadata,
+            "kedro.framework.cli.cli.bootstrap_project", return_value=fake_metadata
         )
         kedro_cli = KedroCLI(fake_metadata.project_path)
         raw_cli_structure = _get_cli_structure(kedro_cli, get_help=False)
@@ -159,13 +151,9 @@ class TestCLIMasking:
             "kedro.framework.cli.cli.importlib.import_module",
             return_value=Module(cli=cli),
         )
+        mocker.patch("kedro.framework.cli.cli._is_project", return_value=True)
         mocker.patch(
-            "kedro.framework.cli.cli._is_project",
-            return_value=True,
-        )
-        mocker.patch(
-            "kedro.framework.cli.cli.bootstrap_project",
-            return_value=fake_metadata,
+            "kedro.framework.cli.cli.bootstrap_project", return_value=fake_metadata
         )
         kedro_cli = KedroCLI(fake_metadata.project_path)
         help_cli_structure = _get_cli_structure(kedro_cli, get_help=True)


### PR DESCRIPTION
## PR Description

The purpose of this PR is to ensure that command arguments are masked client-side, rather than sent to Heap as-is. The best effort way to do this is to understand what commands, options and parameters are available to the user by getting their `KedroCLI` from project path, recursing it and creating a tree-like structure that eventually feeds into a vocabulary of _whitelist terms_. 

This allows the vocabulary to be more maintainable, tailored to each user (e.g. when they create their own CLI extensions), while always masking anything that is not recognised in the whitelist.

This PR is directly related to https://github.com/quantumblacklabs/private-kedro/pull/1266 and the `_recurse_cli` and its wrapper are copies of `tools/cli.py` code.