### PR TITLE
Add PR & issues templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,41 @@
+---
+name: Bug report
+about: If something isn't working
+title: '<Title>'
+labels: 'Issue: Bug Report'
+assignees: ''
+
+---
+
+## Description
+Short description of the problem here.
+
+## Context
+How has this bug affected you? What were you trying to accomplish?
+
+## Steps to Reproduce
+1. [First Step]
+2. [Second Step]
+3. [And so on...]
+
+## Expected Result
+Tell us what should happen.
+
+## Actual Result
+Tell us what happens instead.
+
+```
+-- If you received an error, place it here.
+```
+
+```
+-- Separate them if you have more than one.
+```
+
+## Your Environment
+Include as many relevant details about the environment in which you experienced the bug:
+
+* Kedro-telemetry version used (`pip show kedro-telemetry`):
+* Kedro version used (`pip show kedro` or `kedro -V`):
+* Python version used (`python -V`):
+* Operating system and version:

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Let us know if you have a feature request or enhancement
+title: '<Title>'
+labels: 'Issue: Feature Request'
+assignees: ''
+
+---
+
+## Description
+Is your feature request related to a problem? A clear and concise description of what the problem is: "I'm always frustrated when ..."
+
+## Context
+Why is this change important to you? How would you use it? How can it benefit other users?
+
+## Possible Implementation
+(Optional) Suggest an idea for implementing the addition or change.
+
+## Possible Alternatives
+(Optional) Describe any alternative solutions or features you've considered.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Description
+<!-- Why was this PR created? -->
+
+## Development notes
+<!-- What have you changed, and how has this been tested? -->
+
+## Checklist
+
+- [ ] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/master/CONTRIBUTING.md) guidelines
+- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
+- [ ] Updated the documentation to reflect the code changes
+- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/master/RELEASE.md) file
+- [ ] Added tests to cover my changes


### PR DESCRIPTION
While removing the "Notice" from the PR templates in the other "kedro-" repos I found that we didn't have a template for PRs or issues in this repo yet.